### PR TITLE
Allow for multiple vertex definition sections in an Obj

### DIFF
--- a/pyfite/obj.py
+++ b/pyfite/obj.py
@@ -115,11 +115,11 @@ class Obj:  # pylint: disable=too-many-instance-attributes
 
             elif attribute == 'f':
                 for i, token in enumerate(tokens[1:]):
-                    v = [Obj.INV_IDX] * 3
+                    vf = [Obj.INV_IDX] * 3
                     for j, val in enumerate(token.split('/')):
                         if val:
-                            v[j] = int(val)
-                    self.faces[f][i] = v
+                            vf[j] = int(val)
+                    self.faces[f][i] = vf
                 f += 1
 
     def _customLineProcessing(self, line: str) -> None:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('requirements.txt', 'r') as fh:
 
 setuptools.setup(
     name="pyfite",
-    version="1.0.0",
+    version="1.0.1",
     author="Ryan Hite",
     author_email="rhite@ara.com",
     description="Basic module containing FITE helper classes.",


### PR DESCRIPTION
Objs sometimes take the form

vertex definitions
face definitions

But it is allowed by the standard to do

vertex definitions
face definitions

vertex defintiions
face definitions

Previously pyfite's obj class could only handle the first style.  This fix splits a variable that is used twice with different meanings into two separate variables.